### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PhuzzyMatcher
-### Combination of the FuzzyWuzzy library with Spacy PhraseMatcher
+### Combination of the RapidFuzz library with Spacy PhraseMatcher
 
 I needed a way to match phrases using a fuzzy approach to prepare an annotated dataset to train a model. After searching in forums etc., I realized that I was not the only one looking for this to work, so I share my solution here. 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ decorator==4.4.1
 defusedxml==0.6.0
 entrypoints==0.3
 fuzz==0.1.1
-fuzzywuzzy==0.17.0
 idna==2.8
 importlib-metadata==1.3.0
 ipykernel==5.1.3
@@ -46,10 +45,10 @@ ptyprocess==0.6.0
 Pygments==2.5.2
 pyrsistent==0.15.6
 python-dateutil==2.8.1
-python-Levenshtein==0.12.0
 pytz==2019.3
 pyzmq==18.1.1
 qtconsole==4.6.0
+rapidfuzz==0.7.6
 requests==2.22.0
 Send2Trash==1.5.0
 six==1.13.0

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,7 +1,7 @@
 import nltk
 from nltk.corpus import stopwords
 import re
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 
 


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy